### PR TITLE
Explicitly use k8s v1.29

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,8 @@ resource "kind_cluster" "this" {
         kind: Cluster
         nodes:
         - role: control-plane
+          image: kindest/node:v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
         - role: worker
+          image: kindest/node:v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
     EOF
 }


### PR DESCRIPTION
This pull request addresses the requirement outlined in [PR #5](https://github.com/justenwalker/terraform-provider-kind/pull/5), which is currently pending merge. The purpose is to explicitly specify the version of Kubernetes to align with Flux pre-requirements.

```sh
➜ flux check --pre
► checking prerequisites
✔ Kubernetes 1.29.0 >=1.26.0-0
✔ prerequisites checks passed
```